### PR TITLE
Added Playerjob Call

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -15,6 +15,14 @@ local opponent = nil
 local opponentId = nil
 local finishBlip = nil
 
+RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo) PlayerJob = JobInfo end)
+AddEventHandler('onResourceStart', function(resource)
+	if GetCurrentResourceName() ~= resource then return end
+    QBCore.Functions.GetPlayerData(function(PlayerData)
+        PlayerJob = PlayerData.job
+    end)
+end)
+
 local function dump(o)
    if type(o) == 'table' then
    local s = '{ '
@@ -425,22 +433,26 @@ end
 Citizen.CreateThread(function()
 	local isInCar = false
 	while true do
-		Citizen.Wait(0)					-- mandatory wait
-		local ped = GetPlayerPed(-1)	-- get local ped
-		
-		if IsPedInAnyVehicle(ped, false) then
-			local veh = GetVehiclePedIsIn(ped, false)
-			if isInCar == false then
-				isInCar = true
-				addRadialMenu()
-			end
-		else
-			if isInCar == true then
-				isInCar = false
-				removeRadialMenu()
-			end
-		end
-	end
+        Citizen.Wait(0)					-- mandatory wait
+        local ped = GetPlayerPed(-1)	-- get local ped
+
+        if PlayerJob.name == 'police' then
+            Wait(1000)
+        else
+            if IsPedInAnyVehicle(ped, false) then
+                local veh = GetVehiclePedIsIn(ped, false)
+                if isInCar == false then
+                    isInCar = true
+                    addRadialMenu()
+                end
+            else
+                if isInCar == true then
+                    isInCar = false
+                    removeRadialMenu()
+                end
+            end
+        end
+    end
 end)
 
 RegisterNetEvent('cw-head2head:client:debugMap', function()


### PR DESCRIPTION
Checks player job so police cannot start races. (Can also add Simple check for Onduty as well if you want cops to be able to do shady stuff.) Simple 1 second wait on the script if police job is detected in case a job change occurs later. 